### PR TITLE
DOZ-3928: Fix XSS/Protype Pollution vulnerability in moo tools

### DIFF
--- a/MooTools-More-1.6.0.js
+++ b/MooTools-More-1.6.0.js
@@ -3082,6 +3082,8 @@ String.implement({
 			if (!keys) return;
 			if (decodeValues) value = decodeComponent(value);
 			keys.each(function(key, i){
+				if (key === '__proto__') return;
+
 				if (decodeKeys) key = decodeComponent(key);
 				var current = obj[key];
 


### PR DESCRIPTION
## Issue Background:

It has recently come to our attention that there is a XSS vulnerability where the global object's properties can be modified by adding certain query params to the url when viewing a page. An example of these params would be something like ?__proto__[__random_string__]=alert(1) which essentially allows for a potential script to be injected through the url params. After doing some research, we have found that mootools appears to contain the vulnerability that allows for this to occur. The changes in this PR fixes that!

## Summary of Changes:

1. Add check to see if the key matches '__proto__' in the parseQueryString method.

Closes: [DOZ-3928](https://dzki.atlassian.net/jira/software/c/projects/DOZ/boards/6?selectedIssue=DOZ-3928)

[DOZ-3928]: https://dzki.atlassian.net/browse/DOZ-3928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ