### PR TITLE
DOZ-10385: Fix XSS/Protype Pollution vulnerability in moo tools

### DIFF
--- a/MooTools-More-1.6.0.js
+++ b/MooTools-More-1.6.0.js
@@ -3083,6 +3083,8 @@ String.implement({
 			if (decodeValues) value = decodeComponent(value);
 			keys.each(function(key, i){
 				if (key === '__proto__') return;
+				if (key === 'prototype') return;
+				if (key === 'constructor') return;
 
 				if (decodeKeys) key = decodeComponent(key);
 				var current = obj[key];


### PR DESCRIPTION
## Issue Background:

It has recently come to our attention that there is a XSS vulnerability where the global object's properties can be modified by adding certain query params to the url when viewing a page. An example of these params would be something like ?constructor[__random_string__]=alert(1) which essentially allows for a potential script to be injected through the url params. After doing some research, we have found that mootools appears to contain the vulnerability that allows for this to occur. The changes in this PR fixes that!

## Summary of Changes:

1. Add check to see if the key matches 'constructor' in the parseQueryString method.

Closes: [DOZ-10385](https://dzki.atlassian.net/jira/software/c/projects/DOZ/boards/6?selectedIssue=DOZ-10385)

[DOZ-10385]: https://dzki.atlassian.net/browse/DOZ-10385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ